### PR TITLE
Integrate transcribe metrics with prometheus

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,179 @@
+# AWS Transcribe Metrics for Prometheus using YACE
+
+This setup allows you to collect AWS Transcribe CloudWatch metrics in Prometheus using YACE (Yet Another CloudWatch Exporter).
+
+## Overview
+
+Since YACE doesn't support automatic discovery for AWS Transcribe, this configuration uses static job definitions to collect metrics from CloudWatch.
+
+## Files Structure
+
+```
+.
+├── yace-config.yaml                    # YACE configuration for AWS Transcribe metrics
+├── docker-compose.yml                  # Docker compose for YACE, Prometheus, and Grafana
+├── prometheus.yml                      # Prometheus configuration
+└── grafana-provisioning/              # Grafana auto-provisioning
+    ├── datasources/
+    │   └── prometheus.yml             # Prometheus datasource config
+    └── dashboards/
+        ├── dashboard.yml              # Dashboard provisioning config
+        └── aws-transcribe-dashboard.json  # AWS Transcribe dashboard
+```
+
+## Quick Start
+
+1. **Configure AWS Credentials**
+   
+   Choose one of these methods in `docker-compose.yml`:
+   
+   - **Method 1**: Environment variables (not recommended for production)
+     ```yaml
+     environment:
+       - AWS_ACCESS_KEY_ID=your_access_key
+       - AWS_SECRET_ACCESS_KEY=your_secret_key
+     ```
+   
+   - **Method 2**: AWS profile from host
+     ```yaml
+     volumes:
+       - ~/.aws:/root/.aws:ro
+     environment:
+       - AWS_PROFILE=your_profile_name
+     ```
+   
+   - **Method 3**: IAM role (recommended for EC2/ECS)
+     - No configuration needed if running on EC2/ECS with proper IAM role
+
+2. **Update Regions**
+   
+   Edit `yace-config.yaml` and update the regions to match where your AWS Transcribe services are running:
+   ```yaml
+   regions:
+     - us-east-1
+     - us-west-2
+     - eu-west-1
+   ```
+
+3. **Start the Stack**
+   ```bash
+   docker-compose up -d
+   ```
+
+4. **Access Services**
+   - Prometheus: http://localhost:9090
+   - Grafana: http://localhost:3000 (admin/admin)
+   - YACE metrics: http://localhost:5000/metrics
+
+## YACE Configuration Details
+
+The configuration collects the following AWS Transcribe metrics:
+
+### Request Metrics
+- `TotalRequestCount` - Total number of transcription requests
+- `SuccessfulRequestCount` - Number of successful requests
+- `UserErrorCount` - Client-side errors (4xx)
+- `SyncServerErrorCount` - Server errors for synchronous requests
+- `AsyncServerErrorCount` - Server errors for asynchronous requests
+- `ThrottledCount` - Number of throttled requests
+- `LimitExceededCount` - Requests that exceeded limits
+
+### Performance Metrics
+- `AudioDurationTime` - Duration of audio processed
+- `AsyncJobsInQueue` - Number of jobs waiting in queue
+- `AsyncJobsCompleted` - Number of completed async jobs
+- `AsyncJobsFailed` - Number of failed async jobs
+
+### Dimensions
+The configuration collects metrics with these dimensions:
+- `Domain` - The domain of the transcription (e.g., medical)
+- `ServiceType` - Type of service (batch, streaming)
+- `LanguageCode` - Language used for transcription
+- `ModelName` - The model used for transcription
+
+## Customization
+
+### Adjusting Collection Intervals
+In `yace-config.yaml`:
+```yaml
+period: 300  # CloudWatch period in seconds
+length: 300  # Collection window in seconds
+delay: 120   # Delay to ensure metrics are available
+```
+
+### Adding Specific Dimension Filters
+To collect metrics only for specific languages or models, uncomment and modify the example at the bottom of `yace-config.yaml`.
+
+### Prometheus Metric Relabeling
+The `prometheus.yml` includes metric relabeling rules to make metrics more Prometheus-friendly. For example:
+- `aws_transcribe_total_request_count_sum` → `transcribe_requests_total`
+- `aws_transcribe_audio_duration_time_average` → `transcribe_audio_duration_seconds_avg`
+
+## If You Already Have YACE Running
+
+Since you mentioned you already have YACE running, you can:
+
+1. **Add to existing YACE config**: Copy the `static` section from `yace-config.yaml` to your existing YACE configuration file.
+
+2. **Update Prometheus**: Add the scrape job from `prometheus.yml` to your existing Prometheus configuration:
+   ```yaml
+   - job_name: 'yace-transcribe'
+     static_configs:
+       - targets: ['your-yace-host:5000']
+     scrape_interval: 60s
+     scrape_timeout: 55s
+   ```
+
+3. **Import Grafana Dashboard**: Import the dashboard from `grafana-provisioning/dashboards/aws-transcribe-dashboard.json` into your Grafana instance.
+
+## Troubleshooting
+
+### No Metrics Appearing
+1. Check YACE logs: `docker-compose logs yace`
+2. Verify AWS credentials and permissions
+3. Ensure your AWS account has Transcribe activity in the configured regions
+4. Check if metrics are available in CloudWatch console first
+
+### Required IAM Permissions
+Your AWS credentials need these permissions:
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "cloudwatch:GetMetricStatistics",
+        "cloudwatch:ListMetrics"
+      ],
+      "Resource": "*"
+    }
+  ]
+}
+```
+
+### Metric Delays
+CloudWatch metrics may have a delay of 1-5 minutes. The configuration includes a 2-minute delay to account for this.
+
+## Example Prometheus Queries
+
+```promql
+# Request rate per minute
+rate(aws_transcribe_total_request_count_sum[5m]) * 60
+
+# Success rate percentage
+(sum(rate(aws_transcribe_successful_request_count_sum[5m])) / sum(rate(aws_transcribe_total_request_count_sum[5m]))) * 100
+
+# Average audio duration by language
+avg by (language_code) (aws_transcribe_audio_duration_time_average)
+
+# Error rate by type
+sum by (region) (rate(aws_transcribe_user_error_count_sum[5m]))
+```
+
+## Next Steps
+
+1. Set up alerts in Prometheus for error rates and throttling
+2. Create custom Grafana dashboards for your specific use cases
+3. Consider using recording rules for frequently-used queries
+4. Set up long-term storage for metrics if needed

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,76 @@
+version: '3.8'
+
+services:
+  yace:
+    image: quay.io/prometheuscommunity/yet-another-cloudwatch-exporter:v0.55.0
+    container_name: yace-transcribe
+    ports:
+      - "5000:5000"
+    volumes:
+      - ./yace-config.yaml:/tmp/config.yml:ro
+    environment:
+      # AWS credentials - use one of the following methods:
+      # Method 1: Direct credentials (not recommended for production)
+      # - AWS_ACCESS_KEY_ID=your_access_key
+      # - AWS_SECRET_ACCESS_KEY=your_secret_key
+      
+      # Method 2: Use AWS profile
+      # - AWS_PROFILE=your_profile_name
+      
+      # Method 3: Use IAM role (recommended for EC2/ECS)
+      # No environment variables needed if running on EC2/ECS with proper IAM role
+      
+      # Optional: Set specific region
+      - AWS_REGION=us-east-1
+      
+      # YACE configuration
+      - config.file=/tmp/config.yml
+      - listen-address=:5000
+      - log.level=info
+      
+    # For AWS credentials from host (Method 2)
+    # volumes:
+    #   - ~/.aws:/root/.aws:ro
+    #   - ./yace-config.yaml:/tmp/config.yml:ro
+    
+    restart: unless-stopped
+    
+  # Optional: Add Prometheus if you don't have it running already
+  prometheus:
+    image: prom/prometheus:v2.45.0
+    container_name: prometheus
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus_data:/prometheus
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+      - '--storage.tsdb.path=/prometheus'
+      - '--web.console.libraries=/usr/share/prometheus/console_libraries'
+      - '--web.console.templates=/usr/share/prometheus/consoles'
+      - '--web.enable-lifecycle'
+    restart: unless-stopped
+    depends_on:
+      - yace
+
+  # Optional: Add Grafana for visualization
+  grafana:
+    image: grafana/grafana:10.0.0
+    container_name: grafana
+    ports:
+      - "3000:3000"
+    environment:
+      - GF_SECURITY_ADMIN_USER=admin
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+      - GF_USERS_ALLOW_SIGN_UP=false
+    volumes:
+      - grafana_data:/var/lib/grafana
+      - ./grafana-provisioning:/etc/grafana/provisioning:ro
+    restart: unless-stopped
+    depends_on:
+      - prometheus
+
+volumes:
+  prometheus_data:
+  grafana_data:

--- a/grafana-provisioning/dashboards/aws-transcribe-dashboard.json
+++ b/grafana-provisioning/dashboards/aws-transcribe-dashboard.json
@@ -1,0 +1,692 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "tooltip": false,
+              "viz": false,
+              "legend": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "rate(aws_transcribe_total_request_count_sum[5m])",
+          "legendFormat": "Total Requests - {{region}} {{domain}} {{service_type}} {{language_code}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "rate(aws_transcribe_successful_request_count_sum[5m])",
+          "hide": false,
+          "legendFormat": "Successful Requests - {{region}} {{domain}} {{service_type}} {{language_code}}",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Request Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "values": false,
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": ""
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "(sum(rate(aws_transcribe_successful_request_count_sum[5m])) / sum(rate(aws_transcribe_total_request_count_sum[5m]))) * 100",
+          "legendFormat": "Success Rate",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Success Rate",
+      "type": "gauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "tooltip": false,
+              "viz": false,
+              "legend": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "rate(aws_transcribe_user_error_count_sum[5m])",
+          "legendFormat": "User Errors - {{region}} {{domain}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "rate(aws_transcribe_sync_server_error_count_sum[5m])",
+          "hide": false,
+          "legendFormat": "Sync Server Errors - {{region}} {{domain}}",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "rate(aws_transcribe_async_server_error_count_sum[5m])",
+          "hide": false,
+          "legendFormat": "Async Server Errors - {{region}} {{domain}}",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "rate(aws_transcribe_throttled_count_sum[5m])",
+          "hide": false,
+          "legendFormat": "Throttled - {{region}} {{domain}}",
+          "range": true,
+          "refId": "D"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "rate(aws_transcribe_limit_exceeded_count_sum[5m])",
+          "hide": false,
+          "legendFormat": "Limit Exceeded - {{region}} {{domain}}",
+          "range": true,
+          "refId": "E"
+        }
+      ],
+      "title": "Error Rates",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "tooltip": false,
+              "viz": false,
+              "legend": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "aws_transcribe_audio_duration_time_average",
+          "legendFormat": "Avg Duration - {{region}} {{language_code}} {{model_name}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "aws_transcribe_audio_duration_time_maximum",
+          "hide": false,
+          "legendFormat": "Max Duration - {{region}} {{language_code}} {{model_name}}",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Audio Duration",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "tooltip": false,
+              "viz": false,
+              "legend": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 16
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "aws_transcribe_async_jobs_in_queue_average",
+          "legendFormat": "Jobs in Queue - {{region}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "aws_transcribe_async_jobs_in_queue_maximum",
+          "hide": false,
+          "legendFormat": "Max Jobs in Queue - {{region}}",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Async Jobs Queue",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "tooltip": false,
+              "viz": false,
+              "legend": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 16
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "rate(aws_transcribe_async_jobs_completed_sum[5m])",
+          "legendFormat": "Completed Jobs - {{region}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "rate(aws_transcribe_async_jobs_failed_sum[5m])",
+          "hide": false,
+          "legendFormat": "Failed Jobs - {{region}}",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Async Jobs Status",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 38,
+  "style": "dark",
+  "tags": ["aws", "transcribe", "cloudwatch"],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "Prometheus",
+          "value": "prometheus"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Data Source",
+        "multi": false,
+        "name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "AWS Transcribe Metrics",
+  "uid": "aws-transcribe-metrics",
+  "version": 1,
+  "weekStart": ""
+}

--- a/grafana-provisioning/dashboards/dashboard.yml
+++ b/grafana-provisioning/dashboards/dashboard.yml
@@ -1,0 +1,12 @@
+apiVersion: 1
+
+providers:
+  - name: 'default'
+    orgId: 1
+    folder: ''
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 10
+    allowUiUpdates: true
+    options:
+      path: /etc/grafana/provisioning/dashboards

--- a/grafana-provisioning/datasources/prometheus.yml
+++ b/grafana-provisioning/datasources/prometheus.yml
@@ -1,0 +1,9 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: true

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -1,0 +1,96 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  # YACE scrape configuration for AWS Transcribe metrics
+  - job_name: 'yace-transcribe'
+    static_configs:
+      - targets: ['yace:5000']  # Use 'localhost:5000' if not using Docker
+    scrape_interval: 60s  # Adjust based on your needs
+    scrape_timeout: 55s   # Should be less than scrape_interval
+    
+    # Optional: Add metric relabeling to make metrics easier to work with
+    metric_relabel_configs:
+      # Add a label to identify these as Transcribe metrics
+      - source_labels: [__name__]
+        regex: 'aws_transcribe_.*'
+        target_label: service
+        replacement: 'transcribe'
+      
+      # Rename metrics to be more Prometheus-friendly
+      - source_labels: [__name__]
+        regex: 'aws_transcribe_total_request_count_sum'
+        target_label: __name__
+        replacement: 'transcribe_requests_total'
+      
+      - source_labels: [__name__]
+        regex: 'aws_transcribe_successful_request_count_sum'
+        target_label: __name__
+        replacement: 'transcribe_requests_success_total'
+      
+      - source_labels: [__name__]
+        regex: 'aws_transcribe_user_error_count_sum'
+        target_label: __name__
+        replacement: 'transcribe_errors_user_total'
+      
+      - source_labels: [__name__]
+        regex: 'aws_transcribe_sync_server_error_count_sum'
+        target_label: __name__
+        replacement: 'transcribe_errors_server_sync_total'
+      
+      - source_labels: [__name__]
+        regex: 'aws_transcribe_async_server_error_count_sum'
+        target_label: __name__
+        replacement: 'transcribe_errors_server_async_total'
+      
+      - source_labels: [__name__]
+        regex: 'aws_transcribe_throttled_count_sum'
+        target_label: __name__
+        replacement: 'transcribe_throttled_total'
+      
+      - source_labels: [__name__]
+        regex: 'aws_transcribe_limit_exceeded_count_sum'
+        target_label: __name__
+        replacement: 'transcribe_limit_exceeded_total'
+      
+      - source_labels: [__name__]
+        regex: 'aws_transcribe_audio_duration_time_sum'
+        target_label: __name__
+        replacement: 'transcribe_audio_duration_seconds_total'
+      
+      - source_labels: [__name__]
+        regex: 'aws_transcribe_audio_duration_time_average'
+        target_label: __name__
+        replacement: 'transcribe_audio_duration_seconds_avg'
+      
+      - source_labels: [__name__]
+        regex: 'aws_transcribe_async_jobs_in_queue_average'
+        target_label: __name__
+        replacement: 'transcribe_jobs_queue_avg'
+      
+      - source_labels: [__name__]
+        regex: 'aws_transcribe_async_jobs_completed_sum'
+        target_label: __name__
+        replacement: 'transcribe_jobs_completed_total'
+      
+      - source_labels: [__name__]
+        regex: 'aws_transcribe_async_jobs_failed_sum'
+        target_label: __name__
+        replacement: 'transcribe_jobs_failed_total'
+
+# If you have an existing Prometheus configuration, add this job to your scrape_configs
+# Example of how to add to existing config:
+#
+# scrape_configs:
+#   # Your existing jobs...
+#   - job_name: 'your-existing-job'
+#     static_configs:
+#       - targets: ['your-target:port']
+#   
+#   # Add YACE job here
+#   - job_name: 'yace-transcribe'
+#     static_configs:
+#       - targets: ['yace:5000']
+#     scrape_interval: 60s
+#     scrape_timeout: 55s

--- a/yace-config.yaml
+++ b/yace-config.yaml
@@ -1,0 +1,224 @@
+apiVersion: v1alpha1
+# YACE Configuration for AWS Transcribe Metrics
+# This configuration collects CloudWatch metrics from AWS Transcribe service
+
+static:
+  # AWS Transcribe metrics configuration
+  - name: transcribe-metrics
+    namespace: AWS/Transcribe
+    regions:
+      - us-east-1  # Update with your regions
+      - us-west-2
+      - eu-west-1
+    period: 300  # 5 minutes (CloudWatch period)
+    length: 300  # 5 minutes (data point collection window)
+    delay: 120   # 2 minutes delay to ensure metrics are available
+    metrics:
+      # Request metrics
+      - name: TotalRequestCount
+        statistics: 
+          - Sum
+          - Average
+        dimensions:
+          - name: Domain
+            value: "*"
+          - name: ServiceType
+            value: "*"
+          - name: LanguageCode
+            value: "*"
+          - name: ModelName
+            value: "*"
+      
+      - name: SuccessfulRequestCount
+        statistics: 
+          - Sum
+          - Average
+        dimensions:
+          - name: Domain
+            value: "*"
+          - name: ServiceType
+            value: "*"
+          - name: LanguageCode
+            value: "*"
+          - name: ModelName
+            value: "*"
+      
+      # Error metrics
+      - name: UserErrorCount
+        statistics: 
+          - Sum
+          - Average
+        dimensions:
+          - name: Domain
+            value: "*"
+          - name: ServiceType
+            value: "*"
+          - name: LanguageCode
+            value: "*"
+          - name: ModelName
+            value: "*"
+      
+      - name: SyncServerErrorCount
+        statistics: 
+          - Sum
+        dimensions:
+          - name: Domain
+            value: "*"
+          - name: ServiceType
+            value: "*"
+          - name: LanguageCode
+            value: "*"
+          - name: ModelName
+            value: "*"
+      
+      - name: AsyncServerErrorCount
+        statistics: 
+          - Sum
+        dimensions:
+          - name: Domain
+            value: "*"
+          - name: ServiceType
+            value: "*"
+          - name: LanguageCode
+            value: "*"
+          - name: ModelName
+            value: "*"
+      
+      - name: ThrottledCount
+        statistics: 
+          - Sum
+        dimensions:
+          - name: Domain
+            value: "*"
+          - name: ServiceType
+            value: "*"
+          - name: LanguageCode
+            value: "*"
+          - name: ModelName
+            value: "*"
+      
+      - name: LimitExceededCount
+        statistics: 
+          - Sum
+        dimensions:
+          - name: Domain
+            value: "*"
+          - name: ServiceType
+            value: "*"
+          - name: LanguageCode
+            value: "*"
+          - name: ModelName
+            value: "*"
+      
+      # Performance metrics
+      - name: AudioDurationTime
+        statistics: 
+          - Average
+          - Maximum
+          - Minimum
+          - Sum
+        dimensions:
+          - name: Domain
+            value: "*"
+          - name: ServiceType
+            value: "*"
+          - name: LanguageCode
+            value: "*"
+          - name: ModelName
+            value: "*"
+      
+      # Async job metrics
+      - name: AsyncJobsInQueue
+        statistics: 
+          - Average
+          - Maximum
+        dimensions:
+          - name: Domain
+            value: "*"
+          - name: ServiceType
+            value: "*"
+          - name: LanguageCode
+            value: "*"
+          - name: ModelName
+            value: "*"
+      
+      - name: AsyncJobsCompleted
+        statistics: 
+          - Sum
+        dimensions:
+          - name: Domain
+            value: "*"
+          - name: ServiceType
+            value: "*"
+          - name: LanguageCode
+            value: "*"
+          - name: ModelName
+            value: "*"
+      
+      - name: AsyncJobsFailed
+        statistics: 
+          - Sum
+        dimensions:
+          - name: Domain
+            value: "*"
+          - name: ServiceType
+            value: "*"
+          - name: LanguageCode
+            value: "*"
+          - name: ModelName
+            value: "*"
+
+  # Alternative configuration without dimensions (global metrics)
+  - name: transcribe-metrics-global
+    namespace: AWS/Transcribe
+    regions:
+      - us-east-1  # Update with your regions
+      - us-west-2
+      - eu-west-1
+    period: 300
+    length: 300
+    delay: 120
+    metrics:
+      - name: TotalRequestCount
+        statistics: [Sum]
+      - name: SuccessfulRequestCount
+        statistics: [Sum]
+      - name: UserErrorCount
+        statistics: [Sum]
+      - name: SyncServerErrorCount
+        statistics: [Sum]
+      - name: AsyncServerErrorCount
+        statistics: [Sum]
+      - name: ThrottledCount
+        statistics: [Sum]
+      - name: LimitExceededCount
+        statistics: [Sum]
+      - name: AudioDurationTime
+        statistics: [Sum, Average]
+      - name: AsyncJobsInQueue
+        statistics: [Average, Maximum]
+      - name: AsyncJobsCompleted
+        statistics: [Sum]
+      - name: AsyncJobsFailed
+        statistics: [Sum]
+
+# Optional: Add custom dimensions if you know specific values
+# For example, if you only care about specific language codes:
+#  - name: transcribe-metrics-english
+#    namespace: AWS/Transcribe
+#    regions:
+#      - us-east-1
+#    period: 300
+#    length: 300
+#    delay: 120
+#    metrics:
+#      - name: TotalRequestCount
+#        statistics: [Sum]
+#        dimensions:
+#          - name: LanguageCode
+#            value: en-US
+#      - name: AudioDurationTime
+#        statistics: [Average]
+#        dimensions:
+#          - name: LanguageCode
+#            value: en-US


### PR DESCRIPTION
Add static YACE configuration and a full monitoring stack to collect AWS Transcribe metrics in Prometheus and visualize them in Grafana, as YACE does not support automatic discovery for this service.

---
<a href="https://cursor.com/background-agent?bcId=bc-b9d84877-65f8-411c-87b8-fa9740e527e0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b9d84877-65f8-411c-87b8-fa9740e527e0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

