### PR TITLE
Kubernetes resource restart operator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+__pycache__/
+*.py[cod]
+*.egg-info/
+.pytest_cache/
+.ruff_cache/
+.venv/
+venv/
+dist/
+build/
+.DS_Store
+.idea/
+.vscode/
+.env
+coverage.xml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+# syntax=docker/dockerfile:1.6
+
+FROM python:3.11-slim AS runtime
+
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1
+
+WORKDIR /app
+
+COPY pyproject.toml README.md /app/
+COPY src /app/src
+
+RUN pip install --no-cache-dir .
+
+CMD ["python", "-m", "krr_operator"]

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,24 @@
+PYTHON ?= python3
+POETRY ?= poetry
+PACKAGE = krr_operator
+
+.PHONY: install run lint test fmt clean
+
+install:
+	$(PYTHON) -m pip install --upgrade pip
+	$(PYTHON) -m pip install -e .[dev]
+
+run:
+	KOPF_RUN=1 $(PYTHON) -m $(PACKAGE)
+
+lint:
+	ruff check src tests
+
+test:
+	pytest
+
+fmt:
+	ruff check --select I --fix src tests
+
+clean:
+	rm -rf .ruff_cache .pytest_cache build dist *.egg-info

--- a/README.md
+++ b/README.md
@@ -1,0 +1,134 @@
+# Kubernetes Restart Operator (KRR)
+
+KRR is a Python-based Kubernetes operator that brings structure, auditability, and safety to
+restarting common platform resources such as Deployments, StatefulSets, Strimzi Kafka clusters, and
+Crunchy Postgres clusters. It ships with a single Custom Resource Definition (CRD), **RestartRequest**,
+which captures the intent, strategy, and rollout expectations for each restart.
+
+## Why build KRR?
+
+- **Consistent workflows** – replace ad-hoc `kubectl rollout restart` commands with GitOps-friendly
+  manifests.
+- **First-class support for popular CRDs** – Strimzi and Crunchy Postgres restart workflows follow
+  vendor recommendations out of the box.
+- **Observability ready** – structured JSON logs, explicit status phases, and idempotent spec hashes
+  make it easy to integrate with alerting or incident tooling.
+- **Extensible** – add new target kinds by dropping in additional restarters without changing the CRD.
+
+## Features
+
+- Restart Deployments, StatefulSets, and DaemonSets via deterministic template annotations.
+- Trigger Strimzi rolling updates by annotating Kafka CRs.
+- Request Crunchy Postgres restarts using the official restart annotation.
+- Optional dry-run mode to preview actions.
+- Built-in rollout waiting, readiness polling, and pod selector checks.
+- Kopf-powered reconciliation with retry backoff and status management.
+
+## Repository layout
+
+```
+src/krr_operator/        # Operator source (handlers, restarters, config)
+deploy/crds/             # RestartRequest CRD
+deploy/operator/         # Namespace, RBAC, Deployment manifests
+manifests/examples/      # Sample RestartRequest definitions
+tests/                   # Unit tests for spec validation
+```
+
+## Getting started locally
+
+1. **Install dependencies**
+
+   ```bash
+   pip install -e .[dev]
+   ```
+
+2. **Run tests and linters**
+
+   ```bash
+   make lint test
+   ```
+
+3. **Start the operator against your current kubeconfig**
+
+   ```bash
+   make run
+   ```
+
+   Kopf will connect to whichever cluster is configured in your `KUBECONFIG`. Use `kind`,
+   `minikube`, or an actual cluster.
+
+## Deploying to a cluster
+
+1. Apply the CRD and RBAC/operator manifests (edit the image reference first):
+
+   ```bash
+   kubectl apply -f deploy/crds/restartrequests.restart.krr.sh.yaml
+   kubectl apply -f deploy/operator/krr-operator.yaml
+   ```
+
+2. Build and push an image:
+
+   ```bash
+   docker build -t ghcr.io/<org>/krr-operator:latest .
+   docker push ghcr.io/<org>/krr-operator:latest
+   ```
+
+3. Update `deploy/operator/krr-operator.yaml` with your image reference and re-apply.
+
+The operator creates one Deployment in the `krr-system` namespace and watches all
+`RestartRequest` CRs cluster-wide.
+
+## Creating a restart request
+
+Example manifest for a Deployment restart:
+
+```yaml
+apiVersion: restart.krr.sh/v1alpha1
+kind: RestartRequest
+metadata:
+  name: refresh-web
+spec:
+  target:
+    kind: Deployment
+    name: web
+    namespace: default
+  reason: "Pick up new ConfigMap data"
+  strategy:
+    waitForRollout: true
+    timeoutSeconds: 1200
+```
+
+More examples, including Strimzi Kafka and Postgres clusters, live under
+`manifests/examples/restart-examples.yaml`.
+
+## Supported targets
+
+| Kind             | Action performed                                                                    |
+| ---------------- | ------------------------------------------------------------------------------------ |
+| Deployment       | Patches `spec.template.metadata.annotations` with `krr.sh/restartedAt` timestamp     |
+| StatefulSet      | Same as Deployment                                                                   |
+| DaemonSet        | Same as Deployment                                                                   |
+| StrimziKafka     | Applies the `strimzi.io/manual-rolling-update` annotation to the Kafka CR            |
+| PostgresCluster  | Applies the `postgres-operator.crunchydata.com/restart` annotation to the CR         |
+
+If `spec.labels` are provided, KRR also polls pods matching the selector to ensure readiness.
+
+## Extending the operator
+
+1. Add a new `TargetKind` enum entry inside `src/krr_operator/models.py`.
+2. Teach `RestartCoordinator` how to handle that kind.
+3. Update the CRD schema and documentation.
+4. Contribute tests that exercise the new behavior (mocking Kubernetes clients).
+
+## Contributing
+
+Contributions are welcome! Please open an issue or discussion for substantial feature work. For pull
+requests:
+
+- Keep code formatted with `ruff`.
+- Add or update tests for behavioral changes.
+- Update documentation when adding new capabilities.
+
+## License
+
+MIT – see `LICENSE` for details.

--- a/deploy/crds/restartrequests.restart.krr.sh.yaml
+++ b/deploy/crds/restartrequests.restart.krr.sh.yaml
@@ -1,0 +1,89 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: restartrequests.restart.krr.sh
+spec:
+  group: restart.krr.sh
+  names:
+    plural: restartrequests
+    singular: restartrequest
+    kind: RestartRequest
+    shortNames:
+      - rrq
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              required:
+                - target
+              properties:
+                reason:
+                  type: string
+                  maxLength: 256
+                dryRun:
+                  type: boolean
+                labels:
+                  type: object
+                  additionalProperties:
+                    type: string
+                target:
+                  type: object
+                  required:
+                    - kind
+                    - name
+                  properties:
+                    kind:
+                      type: string
+                      enum:
+                        - Deployment
+                        - StatefulSet
+                        - DaemonSet
+                        - StrimziKafka
+                        - PostgresCluster
+                    name:
+                      type: string
+                    namespace:
+                      type: string
+                    apiVersion:
+                      type: string
+                    plural:
+                      type: string
+                strategy:
+                  type: object
+                  properties:
+                    type:
+                      type: string
+                      enum:
+                        - rolling
+                        - full
+                    waitForRollout:
+                      type: boolean
+                    timeoutSeconds:
+                      type: integer
+                      minimum: 30
+                      maximum: 7200
+                    pollIntervalSeconds:
+                      type: integer
+                      minimum: 1
+                      maximum: 60
+            status:
+              type: object
+              properties:
+                phase:
+                  type: string
+                lastRestartAt:
+                  type: string
+                  format: date-time
+                message:
+                  type: string
+                specHash:
+                  type: string
+      subresources:
+        status: {}

--- a/deploy/operator/krr-operator.yaml
+++ b/deploy/operator/krr-operator.yaml
@@ -1,0 +1,79 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: krr-system
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: krr-operator
+  namespace: krr-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: krr-operator
+rules:
+  - apiGroups: ["restart.krr.sh"]
+    resources: ["restartrequests", "restartrequests/status"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+  - apiGroups: ["apps"]
+    resources: ["deployments", "statefulsets", "daemonsets"]
+    verbs: ["get", "list", "watch", "patch"]
+  - apiGroups: ["kafka.strimzi.io"]
+    resources: ["kafkas"]
+    verbs: ["get", "list", "watch", "patch"]
+  - apiGroups: ["postgres-operator.crunchydata.com"]
+    resources: ["postgresclusters"]
+    verbs: ["get", "list", "watch", "patch"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: krr-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: krr-operator
+subjects:
+  - kind: ServiceAccount
+    name: krr-operator
+    namespace: krr-system
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: krr-operator
+  namespace: krr-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: krr-operator
+  template:
+    metadata:
+      labels:
+        app: krr-operator
+    spec:
+      serviceAccountName: krr-operator
+      containers:
+        - name: manager
+          image: ghcr.io/your-org/krr-operator:latest
+          imagePullPolicy: IfNotPresent
+          command:
+            - python
+          args:
+            - -m
+            - krr_operator
+          env:
+            - name: KRR_LOG_LEVEL
+              value: INFO
+            - name: KRR_RESTART_ANNOTATION
+              value: krr.sh/restartedAt
+            - name: KRR_READINESS_TIMEOUT_SECONDS
+              value: "900"
+            - name: KRR_READINESS_POLL_SECONDS
+              value: "5"

--- a/manifests/examples/restart-examples.yaml
+++ b/manifests/examples/restart-examples.yaml
@@ -1,0 +1,44 @@
+apiVersion: restart.krr.sh/v1alpha1
+kind: RestartRequest
+metadata:
+  name: restart-web-deployment
+spec:
+  target:
+    kind: Deployment
+    name: web
+    namespace: default
+  reason: "Refresh application pods after config change"
+  strategy:
+    waitForRollout: true
+---
+apiVersion: restart.krr.sh/v1alpha1
+kind: RestartRequest
+metadata:
+  name: restart-kafka
+spec:
+  target:
+    kind: StrimziKafka
+    name: demo-cluster
+    namespace: kafka
+    plural: kafkas
+  labels:
+    strimzi.io/cluster: demo-cluster
+  reason: "Apply new Strimzi config"
+  strategy:
+    waitForRollout: true
+    timeoutSeconds: 1800
+---
+apiVersion: restart.krr.sh/v1alpha1
+kind: RestartRequest
+metadata:
+  name: restart-postgres
+spec:
+  target:
+    kind: PostgresCluster
+    name: accounts-db
+    namespace: data
+    plural: postgresclusters
+  dryRun: false
+  labels:
+    postgres-operator.crunchydata.com/cluster: accounts-db
+  reason: "Weekly maintenance"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,48 @@
+[build-system]
+requires = ["hatchling>=1.25"]
+build-backend = "hatchling.build"
+
+[project]
+name = "krr-operator"
+version = "0.1.0"
+description = "Python-based Kubernetes restart operator for workloads, Strimzi Kafka, and PostgreSQL clusters."
+readme = "README.md"
+requires-python = ">=3.10"
+license = { text = "MIT" }
+authors = [
+  { name = "Open Source Contributors" }
+]
+dependencies = [
+  "kopf>=1.37.2",
+  "kubernetes>=30.1.0",
+  "pydantic>=2.7",
+  "python-json-logger>=2.0.0",
+  "pyyaml>=6.0.0"
+]
+
+[project.optional-dependencies]
+dev = [
+  "pytest>=8.0.0",
+  "pytest-asyncio>=0.23",
+  "ruff>=0.6.0",
+  "mypy>=1.10.0",
+  "types-pyyaml"
+]
+
+[project.scripts]
+krr-operator = "krr_operator.__main__:main"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/krr_operator"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py310"
+
+[tool.ruff.lint]
+select = ["E", "F", "W", "I", "UP", "B"]
+
+[tool.pytest.ini_options]
+minversion = "8.0"
+addopts = "-ra --disable-warnings"
+testpaths = ["tests"]

--- a/src/krr_operator/__init__.py
+++ b/src/krr_operator/__init__.py
@@ -1,0 +1,5 @@
+"""Kubernetes Restart Operator package."""
+
+__all__ = ["__version__"]
+
+__version__ = "0.1.0"

--- a/src/krr_operator/__main__.py
+++ b/src/krr_operator/__main__.py
@@ -1,0 +1,18 @@
+"""Entry point for running the operator directly."""
+
+from __future__ import annotations
+
+import kopf
+
+from .logging import configure_logging
+
+
+def main() -> None:
+    """Run Kopf with the operator modules."""
+
+    configure_logging()
+    kopf.run(standalone=True, modules=["krr_operator.handlers.restart_request"])
+
+
+if __name__ == "__main__":
+    main()

--- a/src/krr_operator/config.py
+++ b/src/krr_operator/config.py
@@ -1,0 +1,55 @@
+"""Runtime configuration for the Kubernetes Restart Operator."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from functools import lru_cache
+
+
+@dataclass(frozen=True)
+class OperatorConfig:
+    """Holds configurable runtime knobs sourced from the environment."""
+
+    log_level: str = "INFO"
+    default_namespace: str = "default"
+    restart_annotation_key: str = "krr.sh/restartedAt"
+    readiness_timeout_seconds: int = 900
+    readiness_poll_interval_seconds: int = 5
+    strimzi_group: str = "kafka.strimzi.io"
+    strimzi_version: str = "v1beta2"
+    postgres_group: str = "postgres-operator.crunchydata.com"
+    postgres_version: str = "v1beta1"
+
+    @classmethod
+    def from_env(cls) -> OperatorConfig:
+        """Create configuration loading overrides from environment variables."""
+
+        def _int(name: str, default: int) -> int:
+            value = os.getenv(name)
+            return int(value) if value else default
+
+        return cls(
+            log_level=os.getenv("KRR_LOG_LEVEL", cls.log_level),
+            default_namespace=os.getenv("KRR_DEFAULT_NAMESPACE", cls.default_namespace),
+            restart_annotation_key=os.getenv(
+                "KRR_RESTART_ANNOTATION", cls.restart_annotation_key
+            ),
+            readiness_timeout_seconds=_int(
+                "KRR_READINESS_TIMEOUT_SECONDS", cls.readiness_timeout_seconds
+            ),
+            readiness_poll_interval_seconds=_int(
+                "KRR_READINESS_POLL_SECONDS", cls.readiness_poll_interval_seconds
+            ),
+            strimzi_group=os.getenv("KRR_STRIMZI_GROUP", cls.strimzi_group),
+            strimzi_version=os.getenv("KRR_STRIMZI_VERSION", cls.strimzi_version),
+            postgres_group=os.getenv("KRR_POSTGRES_GROUP", cls.postgres_group),
+            postgres_version=os.getenv("KRR_POSTGRES_VERSION", cls.postgres_version),
+        )
+
+
+@lru_cache(maxsize=1)
+def get_config() -> OperatorConfig:
+    """Return a cached configuration instance."""
+
+    return OperatorConfig.from_env()

--- a/src/krr_operator/exceptions.py
+++ b/src/krr_operator/exceptions.py
@@ -1,0 +1,9 @@
+"""Operator specific exceptions."""
+
+
+class RestartError(RuntimeError):
+    """Raised when a restart operation fails."""
+
+
+class DryRunNotice(RuntimeError):
+    """Raised to short-circuit execution when running in dry-run mode."""

--- a/src/krr_operator/handlers/__init__.py
+++ b/src/krr_operator/handlers/__init__.py
@@ -1,0 +1,1 @@
+"""Event handlers for Kopf."""

--- a/src/krr_operator/handlers/restart_request.py
+++ b/src/krr_operator/handlers/restart_request.py
@@ -1,0 +1,101 @@
+"""Kopf handlers for RestartRequest custom resources."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+from functools import lru_cache
+
+import kopf
+
+from ..config import get_config
+from ..exceptions import RestartError
+from ..kube.clients import get_kube_clients
+from ..kube.restarters import RestartCoordinator
+from ..logging import configure_logging
+from ..models import RestartPhase, RestartRequestSpec
+
+LOGGER = logging.getLogger(__name__)
+
+
+def _hash_spec(spec: dict) -> str:
+    return hashlib.sha256(json.dumps(spec, sort_keys=True).encode("utf-8")).hexdigest()
+
+
+@lru_cache(maxsize=1)
+def _get_coordinator() -> RestartCoordinator:
+    return RestartCoordinator(clients=get_kube_clients(), config=get_config())
+
+
+@kopf.on.startup()
+def configure(settings: kopf.OperatorSettings, **_: object) -> None:
+    """Set Kopf defaults once at startup."""
+
+    configure_logging()
+    cfg = get_config()
+    settings.posting.level = cfg.log_level.upper()
+    settings.watching.server_timeout = 60
+    settings.watching.client_timeout = 70
+    LOGGER.info("KRR operator starting", extra={"log_level": cfg.log_level})
+
+
+@kopf.on.create("restart.krr.sh", "v1alpha1", "restartrequests")
+@kopf.on.update("restart.krr.sh", "v1alpha1", "restartrequests")
+@kopf.on.resume("restart.krr.sh", "v1alpha1", "restartrequests")
+def on_restart_request(spec, status, patch, logger, **_: object):
+    """Main reconciliation loop."""
+
+    cfg = get_config()
+    request = RestartRequestSpec.model_validate(spec)
+    namespace = request.target.namespace or cfg.default_namespace
+    spec_hash = _hash_spec(spec)
+
+    if status:
+        last_hash = status.get("specHash")
+        phase = status.get("phase")
+        if last_hash == spec_hash and phase == RestartPhase.SUCCEEDED.value:
+            logger.info(
+                "Spec already reconciled, skipping",
+                extra={"target": request.target.name, "namespace": namespace},
+            )
+            patch.status["phase"] = RestartPhase.SKIPPED.value
+            return
+
+    patch.status["phase"] = RestartPhase.IN_PROGRESS.value
+    patch.status["namespace"] = namespace
+    patch.status["specHash"] = spec_hash
+
+    coordinator = _get_coordinator()
+
+    try:
+        outcome = coordinator.execute(request, logger=logger)
+        patch.status.update(
+            {
+                "phase": RestartPhase.SUCCEEDED.value,
+                "lastRestartAt": outcome.restarted_at.isoformat(),
+                "details": outcome.details,
+            }
+        )
+        logger.info(
+            "Restart completed",
+            extra={
+                "target.kind": request.target.kind,
+                "target.name": request.target.name,
+                "namespace": namespace,
+            },
+        )
+    except RestartError as exc:
+        patch.status.update({"phase": RestartPhase.FAILED.value, "message": str(exc)})
+        raise kopf.TemporaryError(str(exc), delay=30) from exc
+
+
+@kopf.on.delete("restart.krr.sh", "v1alpha1", "restartrequests")
+def on_delete(body, logger, **_: object):
+    """Log deletes to keep an audit trail."""
+
+    metadata = body.get("metadata", {})
+    logger.info(
+        "RestartRequest deleted",
+        extra={"name": metadata.get("name"), "namespace": metadata.get("namespace")},
+    )

--- a/src/krr_operator/kube/__init__.py
+++ b/src/krr_operator/kube/__init__.py
@@ -1,0 +1,1 @@
+"""Kubernetes helpers for the restart operator."""

--- a/src/krr_operator/kube/clients.py
+++ b/src/krr_operator/kube/clients.py
@@ -1,0 +1,39 @@
+"""Helpers for initializing Kubernetes API clients."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from functools import lru_cache
+
+from kubernetes import client, config
+from kubernetes.config.config_exception import ConfigException
+
+
+@dataclass(frozen=True)
+class KubeClients:
+    """Strongly typed handle to Kubernetes client instances."""
+
+    apps: client.AppsV1Api
+    core: client.CoreV1Api
+    custom: client.CustomObjectsApi
+
+
+def _load_config() -> None:
+    """Attempt to load in-cluster configuration with a fallback to kubeconfig."""
+
+    try:
+        config.load_incluster_config()
+    except ConfigException:
+        config.load_kube_config()
+
+
+@lru_cache(maxsize=1)
+def get_kube_clients() -> KubeClients:
+    """Return Kubernetes client handles, caching to avoid re-initialization."""
+
+    _load_config()
+    return KubeClients(
+        apps=client.AppsV1Api(),
+        core=client.CoreV1Api(),
+        custom=client.CustomObjectsApi(),
+    )

--- a/src/krr_operator/kube/restarters.py
+++ b/src/krr_operator/kube/restarters.py
@@ -1,0 +1,275 @@
+"""Restart execution helpers."""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+
+from kubernetes import client
+from kubernetes.client import ApiException
+
+from ..config import OperatorConfig
+from ..exceptions import RestartError
+from ..models import RestartOutcome, RestartRequestSpec, RestartStrategy, TargetKind
+from .clients import KubeClients
+
+LOG = logging.getLogger(__name__)
+
+
+ANNOTATION_STRIMZI = "strimzi.io/manual-rolling-update"
+ANNOTATION_CRUNCHY = "postgres-operator.crunchydata.com/restart"
+
+
+@dataclass
+class RestartCoordinator:
+    """Dispatches restart requests to concrete implementations."""
+
+    clients: KubeClients
+    config: OperatorConfig
+
+    def execute(self, spec: RestartRequestSpec, logger: logging.Logger) -> RestartOutcome:
+        """Run the restart flow for the provided spec."""
+
+        namespace = spec.target.namespace or self.config.default_namespace
+        timestamp = datetime.now(timezone.utc).isoformat()
+        logger.info(
+            "Restart requested",
+            extra={
+                "target.kind": spec.target.kind,
+                "target.name": spec.target.name,
+                "namespace": namespace,
+                "reason": spec.reason,
+                "dry_run": spec.dry_run,
+            },
+        )
+
+        if spec.dry_run:
+            return RestartOutcome.now(
+                target_kind=spec.target.kind,
+                target_name=spec.target.name,
+                namespace=namespace,
+                details={"dryRun": "true", "timestamp": timestamp},
+            )
+
+        if spec.target.kind in {
+            TargetKind.DEPLOYMENT,
+            TargetKind.STATEFUL_SET,
+            TargetKind.DAEMON_SET,
+        }:
+            outcome = self._restart_workload(spec, namespace, timestamp, logger)
+        elif spec.target.kind is TargetKind.STRIMZI_KAFKA:
+            outcome = self._restart_strimzi(spec, namespace, timestamp)
+        elif spec.target.kind is TargetKind.POSTGRES_CLUSTER:
+            outcome = self._restart_postgres(spec, namespace, timestamp)
+        else:
+            raise RestartError(f"Unsupported target kind: {spec.target.kind}")
+
+        if spec.strategy.wait_for_rollout:
+            self._wait_for_rollout(spec, namespace, logger)
+
+        if spec.labels and spec.strategy.wait_for_rollout:
+            self._wait_for_selector(namespace, spec.labels, spec.strategy, logger)
+
+        return outcome
+
+    def _restart_workload(
+        self,
+        spec: RestartRequestSpec,
+        namespace: str,
+        timestamp: str,
+        logger: logging.Logger,
+    ) -> RestartOutcome:
+        patch_body = {
+            "metadata": {
+                "annotations": {
+                    self.config.restart_annotation_key: timestamp,
+                }
+            },
+            "spec": {
+                "template": {
+                    "metadata": {
+                        "annotations": {
+                            self.config.restart_annotation_key: timestamp,
+                        }
+                    }
+                }
+            },
+        }
+
+        patch = client.V1Patch(patch_body)
+
+        try:
+            if spec.target.kind is TargetKind.DEPLOYMENT:
+                self.clients.apps.patch_namespaced_deployment(
+                    name=spec.target.name, namespace=namespace, body=patch
+                )
+            elif spec.target.kind is TargetKind.STATEFUL_SET:
+                self.clients.apps.patch_namespaced_stateful_set(
+                    name=spec.target.name, namespace=namespace, body=patch
+                )
+            elif spec.target.kind is TargetKind.DAEMON_SET:
+                self.clients.apps.patch_namespaced_daemon_set(
+                    name=spec.target.name, namespace=namespace, body=patch
+                )
+        except ApiException as exc:
+            raise RestartError(f"Failed to patch workload {spec.target.kind}: {exc}") from exc
+
+        logger.info(
+            "Workload template annotation patched",
+            extra={
+                "target.kind": spec.target.kind,
+                "target.name": spec.target.name,
+                "namespace": namespace,
+            },
+        )
+
+        return RestartOutcome.now(
+            target_kind=spec.target.kind,
+            target_name=spec.target.name,
+            namespace=namespace,
+            details={"annotation": self.config.restart_annotation_key, "value": timestamp},
+        )
+
+    def _restart_strimzi(
+        self, spec: RestartRequestSpec, namespace: str, timestamp: str
+    ) -> RestartOutcome:
+        patch = {"metadata": {"annotations": {ANNOTATION_STRIMZI: timestamp}}}
+
+        try:
+            self.clients.custom.patch_namespaced_custom_object(
+                group=self.config.strimzi_group,
+                version=self.config.strimzi_version,
+                namespace=namespace,
+                plural=spec.target.plural or "kafkas",
+                name=spec.target.name,
+                body=patch,
+            )
+        except ApiException as exc:
+            raise RestartError(f"Failed to patch Strimzi Kafka resource: {exc}") from exc
+
+        return RestartOutcome.now(
+            target_kind=spec.target.kind,
+            target_name=spec.target.name,
+            namespace=namespace,
+            details={"annotation": ANNOTATION_STRIMZI, "value": timestamp},
+        )
+
+    def _restart_postgres(
+        self, spec: RestartRequestSpec, namespace: str, timestamp: str
+    ) -> RestartOutcome:
+        patch = {"metadata": {"annotations": {ANNOTATION_CRUNCHY: timestamp}}}
+
+        plural = spec.target.plural or "postgresclusters"
+
+        try:
+            self.clients.custom.patch_namespaced_custom_object(
+                group=self.config.postgres_group,
+                version=self.config.postgres_version,
+                namespace=namespace,
+                plural=plural,
+                name=spec.target.name,
+                body=patch,
+            )
+        except ApiException as exc:
+            raise RestartError(f"Failed to patch Postgres cluster: {exc}") from exc
+
+        return RestartOutcome.now(
+            target_kind=spec.target.kind,
+            target_name=spec.target.name,
+            namespace=namespace,
+            details={"annotation": ANNOTATION_CRUNCHY, "value": timestamp},
+        )
+
+    def _wait_for_rollout(
+        self, spec: RestartRequestSpec, namespace: str, logger: logging.Logger
+    ) -> None:
+        """Wait for Kubernetes workload rollouts."""
+
+        deadline = time.time() + spec.strategy.timeout_seconds
+
+        while time.time() < deadline:
+            if spec.target.kind is TargetKind.DEPLOYMENT:
+                if self._deployment_ready(spec.target.name, namespace):
+                    logger.info("Deployment rollout completed", extra={"target": spec.target.name})
+                    return
+            elif spec.target.kind is TargetKind.STATEFUL_SET:
+                if self._stateful_set_ready(spec.target.name, namespace):
+                    logger.info("StatefulSet rollout completed", extra={"target": spec.target.name})
+                    return
+            elif spec.target.kind is TargetKind.DAEMON_SET:
+                if self._daemon_set_ready(spec.target.name, namespace):
+                    logger.info("DaemonSet rollout completed", extra={"target": spec.target.name})
+                    return
+            else:
+                # For CRDs we rely on label selectors instead.
+                return
+
+            time.sleep(spec.strategy.poll_interval_seconds)
+
+        raise RestartError(
+            f"Timeout waiting for {spec.target.kind} {spec.target.name} rollout completion"
+        )
+
+    def _deployment_ready(self, name: str, namespace: str) -> bool:
+        dep = self.clients.apps.read_namespaced_deployment_status(name=name, namespace=namespace)
+        spec_replicas = dep.spec.replicas or 0
+        status = dep.status
+        return (
+            status.updated_replicas == spec_replicas
+            and status.available_replicas == spec_replicas
+            and status.observed_generation is not None
+            and dep.metadata.generation is not None
+            and status.observed_generation >= dep.metadata.generation
+        )
+
+    def _stateful_set_ready(self, name: str, namespace: str) -> bool:
+        sts = self.clients.apps.read_namespaced_stateful_set_status(name=name, namespace=namespace)
+        spec_replicas = sts.spec.replicas or 0
+        status = sts.status
+        return (
+            status.ready_replicas == spec_replicas
+            and status.current_replicas == spec_replicas
+            and status.update_revision == status.current_revision
+        )
+
+    def _daemon_set_ready(self, name: str, namespace: str) -> bool:
+        ds = self.clients.apps.read_namespaced_daemon_set_status(name=name, namespace=namespace)
+        status = ds.status
+        return status.desired_number_scheduled == status.number_available
+
+    def _wait_for_selector(
+        self,
+        namespace: str,
+        labels: dict[str, str],
+        strategy: RestartStrategy,
+        logger: logging.Logger,
+    ) -> None:
+        """Wait for pods matching the selector to become ready."""
+
+        selector = ",".join(f"{key}={value}" for key, value in labels.items())
+        deadline = time.time() + strategy.timeout_seconds
+
+        while time.time() < deadline:
+            pods = self.clients.core.list_namespaced_pod(
+                namespace=namespace, label_selector=selector
+            ).items
+            if pods and all(_pod_ready(pod) for pod in pods):
+                logger.info(
+                    "All pods for selector became ready",
+                    extra={"namespace": namespace, "selector": selector},
+                )
+                return
+            time.sleep(strategy.poll_interval_seconds)
+
+        raise RestartError(f"Timeout waiting for pods with selector {selector} to become ready")
+
+
+def _pod_ready(pod: client.V1Pod) -> bool:
+    if pod.status is None or pod.status.conditions is None:
+        return False
+    for condition in pod.status.conditions:
+        if condition.type == "Ready":
+            return condition.status == "True"
+    return False

--- a/src/krr_operator/logging.py
+++ b/src/krr_operator/logging.py
@@ -1,0 +1,23 @@
+"""Logging helpers."""
+
+from __future__ import annotations
+
+import logging
+
+from pythonjsonlogger import jsonlogger
+
+from .config import get_config
+
+
+def configure_logging() -> None:
+    """Configure structured logging for the operator."""
+
+    config = get_config()
+    root = logging.getLogger()
+    root.setLevel(config.log_level.upper())
+    handler = logging.StreamHandler()
+    formatter = jsonlogger.JsonFormatter(
+        "%(asctime)s %(levelname)s %(name)s %(message)s", rename_fields={"asctime": "ts"}
+    )
+    handler.setFormatter(formatter)
+    root.handlers = [handler]

--- a/src/krr_operator/models.py
+++ b/src/krr_operator/models.py
@@ -1,0 +1,96 @@
+"""Data models shared by controllers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from enum import Enum
+
+from pydantic import BaseModel, Field, field_validator
+
+
+class TargetKind(str, Enum):
+    DEPLOYMENT = "Deployment"
+    STATEFUL_SET = "StatefulSet"
+    DAEMON_SET = "DaemonSet"
+    STRIMZI_KAFKA = "StrimziKafka"
+    POSTGRES_CLUSTER = "PostgresCluster"
+
+
+class StrategyType(str, Enum):
+    ROLLING = "rolling"
+    FULL = "full"
+
+
+class RestartStrategy(BaseModel):
+    """Fine grained controls for restart execution."""
+
+    type: StrategyType = StrategyType.ROLLING
+    wait_for_rollout: bool = True
+    timeout_seconds: int = Field(900, ge=30, le=7200)
+    poll_interval_seconds: int = Field(5, ge=1, le=60)
+
+
+class RestartTarget(BaseModel):
+    """Target object that should be restarted."""
+
+    kind: TargetKind
+    name: str
+    namespace: str | None = None
+    api_version: str | None = None
+    plural: str | None = None
+
+    @field_validator("namespace", mode="before")
+    @classmethod
+    def default_namespace(cls, namespace: str | None) -> str | None:
+        """Normalize empty strings to None."""
+
+        if namespace == "":
+            return None
+        return namespace
+
+
+class RestartRequestSpec(BaseModel):
+    """Schema for the RestartRequest custom resource spec."""
+
+    target: RestartTarget
+    reason: str | None = None
+    strategy: RestartStrategy = RestartStrategy()
+    dry_run: bool = False
+    labels: dict[str, str] | None = None
+
+
+class RestartPhase(str, Enum):
+    PENDING = "Pending"
+    IN_PROGRESS = "InProgress"
+    SUCCEEDED = "Succeeded"
+    FAILED = "Failed"
+    SKIPPED = "Skipped"
+
+
+@dataclass
+class RestartOutcome:
+    """Runtime result describing the restart event."""
+
+    target_kind: TargetKind
+    target_name: str
+    namespace: str
+    restarted_at: datetime
+    details: dict[str, str] | None = None
+
+    @classmethod
+    def now(
+        cls,
+        *,
+        target_kind: TargetKind,
+        target_name: str,
+        namespace: str,
+        details: dict[str, str] | None = None,
+    ) -> RestartOutcome:
+        return cls(
+            target_kind=target_kind,
+            target_name=target_name,
+            namespace=namespace,
+            restarted_at=datetime.now(timezone.utc),
+            details=details,
+        )

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,31 @@
+from krr_operator.models import RestartRequestSpec, TargetKind
+
+
+def test_restart_spec_defaults():
+    spec = RestartRequestSpec.model_validate(
+        {
+            "target": {
+                "kind": TargetKind.DEPLOYMENT,
+                "name": "demo",
+                "namespace": "demo-ns",
+            }
+        }
+    )
+
+    assert spec.strategy.wait_for_rollout is True
+    assert spec.strategy.timeout_seconds == 900
+    assert spec.target.namespace == "demo-ns"
+
+
+def test_blank_namespace_becomes_none():
+    spec = RestartRequestSpec.model_validate(
+        {
+            "target": {
+                "kind": TargetKind.STATEFUL_SET,
+                "name": "data",
+                "namespace": "",
+            }
+        }
+    )
+
+    assert spec.target.namespace is None


### PR DESCRIPTION
Introduces a Kubernetes Restart Operator (KRR) to provide a structured and auditable way to restart Kubernetes workloads, Strimzi Kafka, and Crunchy Postgres clusters.

---
<a href="https://cursor.com/background-agent?bcId=bc-ee01915d-b1a1-4e4d-b3b0-8e1ba43c3f0a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ee01915d-b1a1-4e4d-b3b0-8e1ba43c3f0a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

